### PR TITLE
Option --others_var is deprecated / irrelevant since 4.2, and will be…

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -155,7 +155,7 @@ popd
 ynh_script_progression --message="Configuring a systemd service..." --weight=1
 
 # Create a dedicated systemd config
-ynh_add_systemd_config --others_var="ynh_node_load_PATH ynh_npm"
+ynh_add_systemd_config
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -182,7 +182,7 @@ ynh_use_logrotate --non-append
 ynh_script_progression --message="Upgrading systemd configuration..." --weight=1
 
 # Create a dedicated systemd config
-ynh_add_systemd_config --others_var="ynh_node_load_PATH ynh_npm"
+ynh_add_systemd_config
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION
… removed in Bullseye. Yunohost now manages conf using ynh_add_config which automatically replace all __FOOBAR__ by $foobar

